### PR TITLE
[Breaking] Change validate/parse method signature

### DIFF
--- a/packages/schm/README.md
+++ b/packages/schm/README.md
@@ -59,15 +59,15 @@ Parses a schema based on given values.
 
 **Parameters**
 
--   `schema` **[Schema](#schema)** 
 -   `values` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
+-   `schema` **[Schema](#schema)** 
 
 **Examples**
 
 ```javascript
 parse(
+  { foo: 1, bar: '1' },
   schema({ foo: String, bar: Number }),
-  { foo: 1, bar: '1' }
 )
 // -> { foo: '1', bar: 1 }
 
@@ -162,8 +162,8 @@ Validates a schema based on given values.
 
 **Parameters**
 
--   `schema` **[Schema](#schema)** 
 -   `values` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
+-   `schema` **[Schema](#schema)** 
 
 **Examples**
 
@@ -179,7 +179,7 @@ const userSchema = schema({
   }
 })
 
-validate(userSchema, { name: 'John', age: 17 })
+validate({ name: 'John', age: 17 }, userSchema)
   .then((parsedValues) => {
     console.log('Yaay!', parsedValues)
   })

--- a/packages/schm/src/parse.js
+++ b/packages/schm/src/parse.js
@@ -6,16 +6,16 @@ import type { Schema } from './types'
  * Parses a schema based on given values.
  * @example
  * parse(
+ *   { foo: 1, bar: '1' },
  *   schema({ foo: String, bar: Number }),
- *   { foo: 1, bar: '1' }
  * )
  * // -> { foo: '1', bar: 1 }
  *
  * // can also be used directly from schema
  * schema({ foo: String, bar: Number }).parse({ foo: 1, bar: '1' })
  */
-const parse = (schema: Schema, values?: Object = {}): Object => (
-  mapValuesToSchema(schema, values, (value, options, paramName) => (
+const parse = (values?: Object = {}, schema: Schema): Object => (
+  mapValuesToSchema(values, schema, (value, options, paramName) => (
     Object.keys(options).reduce((finalValue, optionName) => {
       const option = options[optionName]
       const parser = schema.parsers[optionName]

--- a/packages/schm/src/schema.js
+++ b/packages/schm/src/schema.js
@@ -30,10 +30,10 @@ const defaultSchema = (params?: Object = {}): Schema => ({
   parsers,
   validators,
   parse(values) {
-    return parse(this, values)
+    return parse(values, this)
   },
   validate(values) {
-    return validate(this, values)
+    return validate(values, this)
   },
   merge(...schemas) {
     return merge({}, this, ...schemas)

--- a/packages/schm/src/utils.js
+++ b/packages/schm/src/utils.js
@@ -23,8 +23,8 @@ export const isSchema = (schema: ?Schema): boolean => !!(
 )
 
 export const mapValuesToSchema = (
-  schema: Schema,
   values: Object,
+  schema: Schema,
   transformValue: TransformValueFunction,
   paramNames: string[] = []
 ): Object => (
@@ -35,8 +35,8 @@ export const mapValuesToSchema = (
 
     if (isSchema(options)) {
       finalValue = mapValuesToSchema(
-        options,
         value,
+        options,
         transformValue,
         [...paramNames, paramName]
       )
@@ -46,8 +46,8 @@ export const mapValuesToSchema = (
       if (isSchema(options[0])) {
         finalValue = arrayValue.map((val, i) =>
           mapValuesToSchema(
-            options[0],
             options[0].parse(val),
+            options[0],
             transformValue,
             [...paramNames, paramName, `${i}`]
           ))

--- a/packages/schm/src/validate.js
+++ b/packages/schm/src/validate.js
@@ -46,7 +46,7 @@ const createErrorObject = (
  *   }
  * })
  *
- * validate(userSchema, { name: 'John', age: 17 })
+ * validate({ name: 'John', age: 17 }, userSchema)
  *   .then((parsedValues) => {
  *     console.log('Yaay!', parsedValues)
  *   })
@@ -65,12 +65,12 @@ const createErrorObject = (
  * }]
  * *\/
  */
-const validate = (schema: Schema, values?: Object = {}): Promise<ValidationError[]> => {
-  const parsed = parse(schema, values)
+const validate = (values?: Object = {}, schema: Schema): Promise<ValidationError[]> => {
+  const parsed = parse(values, schema)
   const promises = []
   const errors = []
 
-  mapValuesToSchema(schema, parsed, (value, options, paramName, paramPath) => {
+  mapValuesToSchema(parsed, schema, (value, options, paramName, paramPath) => {
     let error
 
     Object.keys(options).forEach((optionName) => {

--- a/packages/schm/test/parse.test.js
+++ b/packages/schm/test/parse.test.js
@@ -13,96 +13,93 @@ it('throws when parser is not a function', () => {
       bar: 'notfunction',
     },
   }))
-  expect(() => parse(schm, { foo: 'foo' })).toThrow()
+  expect(() => parse({ foo: 'foo' }, schm)).toThrow()
 })
 
 test('no schema', () => {
-  expect(parse(schema(), { foo: 2 })).toEqual({})
+  expect(parse({ foo: 2 }, schema())).toEqual({})
 })
 
 test('type', () => {
-  expect(parse(schema({ foo: String }), { foo: 2 })).toEqual({ foo: '2' })
-
-  expect(parse(schema({ foo: { type: String } }), { foo: 2 })).toEqual({ foo: '2' })
+  expect(parse({ foo: 2 }, schema({ foo: String }))).toEqual({ foo: '2' })
+  expect(parse({ foo: 2 }, schema({ foo: { type: String } }))).toEqual({ foo: '2' })
 })
 
 test('set', () => {
   expect(parse(
+    { foo: 'bar' },
     schema({ foo: { type: String, set: value => `${value}!!` } }),
-    { foo: 'bar' }
   )).toEqual({ foo: 'bar!!' })
 })
 
 test('get', () => {
   expect(parse(
+    { foo: 'bar' },
     schema({ foo: { type: String, get: value => `${value}!!` } }),
-    { foo: 'bar' }
   )).toEqual({ foo: 'bar!!' })
 })
 
 test('lowercase', () => {
   expect(parse(
+    { foo: 'FOO' },
     schema({ foo: { type: String, lowercase: true } }),
-    { foo: 'FOO' }
   )).toEqual({ foo: 'foo' })
 
-  expect(parse(schema({ foo: { type: String, default: 'FOO', lowercase: true } }))).toEqual({ foo: 'foo' })
+  expect(parse(undefined, schema({ foo: { type: String, default: 'FOO', lowercase: true } }))).toEqual({ foo: 'foo' })
 })
 
 test('uppercase', () => {
   expect(parse(
+    { foo: 'foo' },
     schema({ foo: { type: String, uppercase: true } }),
-    { foo: 'foo' }
   )).toEqual({ foo: 'FOO' })
 
-  expect(parse(schema({ foo: { type: String, default: 'foo', uppercase: true } }))).toEqual({ foo: 'FOO' })
+  expect(parse(undefined, schema({ foo: { type: String, default: 'foo', uppercase: true } }))).toEqual({ foo: 'FOO' })
 })
 
 test('trim', () => {
   expect(parse(
+    { foo: '  bar ' },
     schema({ foo: { type: String, trim: true } }),
-    { foo: '  bar ' }
   )).toEqual({ foo: 'bar' })
 
-  expect(parse(schema({ foo: { type: String, default: '  bar   ', trim: true } }))).toEqual({ foo: 'bar' })
+  expect(parse(undefined, schema({ foo: { type: String, default: '  bar   ', trim: true } }))).toEqual({ foo: 'bar' })
 })
 
 test('default', () => {
-  expect(parse(schema({ foo: 'bar' }))).toEqual({ foo: 'bar' })
-
-  expect(parse(schema({ foo: 'bar' }), { foo: 2 })).toEqual({ foo: '2' })
-
-  expect(parse(schema({ foo: { type: String, default: 'bar' } }))).toEqual({ foo: 'bar' })
+  expect(parse(undefined, schema({ foo: 'bar' }))).toEqual({ foo: 'bar' })
+  expect(parse({ foo: 2 }, schema({ foo: 'bar' }))).toEqual({ foo: '2' })
+  expect(parse(undefined, schema({ foo: { type: String, default: 'bar' } }))).toEqual({ foo: 'bar' })
 })
 
 describe('nested', () => {
   test('empty object', () => {
-    expect(parse(schema({ foo: {} }), { foo: 2 })).toEqual({ foo: {} })
+    expect(parse({ foo: 2 }, schema({ foo: {} }))).toEqual({ foo: {} })
   })
 
   test('object with type properties', () => {
     expect(parse(
+      { foo: { bar: 1, baz: '2' } },
       schema({ foo: { bar: String, baz: Number } }),
-      { foo: { bar: 1, baz: '2' } }
     )).toEqual({ foo: { bar: '1', baz: 2 } })
   })
 
   test('object with type', () => {
     expect(parse(
+      { foo: { bar: 1 } },
       schema({ foo: { type: Object, bar: String } }),
-      { foo: { bar: 1 } }
     )).toEqual({ foo: { bar: 1 } })
   })
 
   test('nested array of object', () => {
     expect(parse(
+      { foo: [{ bar: 1, baz: '2' }, { bar: '1', baz: 2 }] },
       schema({ foo: [{ bar: String, baz: Number }] }),
-      { foo: [{ bar: 1, baz: '2' }, { bar: '1', baz: 2 }] }
     )).toEqual({ foo: [{ bar: '1', baz: 2 }, { bar: '1', baz: 2 }] })
   })
 
   test('extremely nested', () => {
     const obj = qux => ({ foo: { bar: [{ baz: { qux } }] } })
-    expect(parse(schema(obj(String)), obj(1))).toEqual(obj('1'))
+    expect(parse(obj(1), schema(obj(String)))).toEqual(obj('1'))
   })
 })

--- a/packages/schm/test/utils.test.js
+++ b/packages/schm/test/utils.test.js
@@ -32,7 +32,7 @@ test('mapValuesToSchema', () => {
     value,
     paramPath,
   }))
-  expect(mapValuesToSchema(schm, values, fn)).toEqual({
+  expect(mapValuesToSchema(values, schm, fn)).toEqual({
     foo: {
       paramName: 'foo',
       options: {

--- a/packages/schm/test/validate.test.js
+++ b/packages/schm/test/validate.test.js
@@ -9,7 +9,7 @@ describe('validate', () => {
         validate: () => false,
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with promise', async () => {
@@ -19,7 +19,7 @@ describe('validate', () => {
         validate: () => Promise.reject(),
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with function and message array', async () => {
@@ -29,7 +29,7 @@ describe('validate', () => {
         validate: [() => false, '{VALUE} is wrong!'],
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with function and message object', async () => {
@@ -42,7 +42,7 @@ describe('validate', () => {
         },
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with promise and message array', async () => {
@@ -52,7 +52,7 @@ describe('validate', () => {
         validate: [() => Promise.reject(), '{VALUE} is wrong!'],
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with promise and message object', async () => {
@@ -65,7 +65,7 @@ describe('validate', () => {
         },
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with nested param', async () => {
@@ -77,7 +77,7 @@ describe('validate', () => {
         }],
       },
     })
-    await expect(validate(schm, { foo: { bar: ['right', 'wrong'] } })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: { bar: ['right', 'wrong'] } }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with multiple function validators', async () => {
@@ -90,8 +90,8 @@ describe('validate', () => {
         ],
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
-    await expect(validate(schm, { foo: 'notright' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'notright' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with multiple array validators', async () => {
@@ -104,8 +104,8 @@ describe('validate', () => {
         ],
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
-    await expect(validate(schm, { foo: 'notright' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'notright' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with multiple object validators', async () => {
@@ -118,8 +118,8 @@ describe('validate', () => {
         ],
       },
     })
-    await expect(validate(schm, { foo: 'wrong' })).rejects.toMatchSnapshot()
-    await expect(validate(schm, { foo: 'notright' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong' }, schm)).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'notright' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with multiple params', async () => {
@@ -127,7 +127,7 @@ describe('validate', () => {
       foo: { type: String, validate: () => false },
       bar: { type: String, validate: () => false },
     })
-    await expect(validate(schm, { foo: 'wrong', bar: 'wrong' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'wrong', bar: 'wrong' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes with function', async () => {
@@ -137,7 +137,7 @@ describe('validate', () => {
         validate: () => true,
       },
     })
-    await expect(validate(schm, { foo: 'right' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 'right' }, schm)).resolves.toMatchSnapshot()
   })
 
   it('passes with promise', async () => {
@@ -147,7 +147,7 @@ describe('validate', () => {
         validate: () => Promise.resolve(),
       },
     })
-    await expect(validate(schm, { foo: 'right' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 'right' }, schm)).resolves.toMatchSnapshot()
   })
 
   it('throws if value is not a function', () => {
@@ -157,7 +157,7 @@ describe('validate', () => {
         validate: 'foo',
       },
     })
-    expect(() => validate(schm, { foo: 'right' })).toThrow()
+    expect(() => validate({ foo: 'right' }, schm)).toThrow()
   })
 })
 
@@ -169,7 +169,7 @@ describe('required', () => {
         required: true,
       },
     })
-    await expect(validate(schm)).rejects.toMatchSnapshot()
+    await expect(validate(undefined, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -179,7 +179,7 @@ describe('required', () => {
         required: [true, 'foo'],
       },
     })
-    await expect(validate(schm)).rejects.toMatchSnapshot()
+    await expect(validate(undefined, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -189,7 +189,7 @@ describe('required', () => {
         required: true,
       },
     })
-    await expect(validate(schm, { foo: 'foo' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 'foo' }, schm)).resolves.toMatchSnapshot()
   })
 })
 
@@ -201,7 +201,7 @@ describe('match', () => {
         match: /foo/,
       },
     })
-    await expect(validate(schm, { foo: 'bar' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'bar' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -211,7 +211,7 @@ describe('match', () => {
         match: [/foo/, 'foo'],
       },
     })
-    await expect(validate(schm, { foo: 'bar' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'bar' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -221,7 +221,7 @@ describe('match', () => {
         match: /foo/,
       },
     })
-    await expect(validate(schm, { foo: 'foo' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 'foo' }, schm)).resolves.toMatchSnapshot()
   })
 
   it('throws if value is not a regex', () => {
@@ -231,7 +231,7 @@ describe('match', () => {
         match: 'foo',
       },
     })
-    expect(() => validate(schm, { foo: 'foo' })).toThrow()
+    expect(() => validate({ foo: 'foo' }, schm)).toThrow()
   })
 })
 
@@ -243,7 +243,7 @@ describe('enum', () => {
         enum: ['foo', 'bar'],
       },
     })
-    await expect(validate(schm, { foo: 'baz' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'baz' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message object', async () => {
@@ -253,7 +253,7 @@ describe('enum', () => {
         enum: { values: ['foo', 'bar'], message: 'foo' },
       },
     })
-    await expect(validate(schm, { foo: 'baz' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 'baz' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -263,7 +263,7 @@ describe('enum', () => {
         enum: ['foo', 'bar'],
       },
     })
-    await expect(validate(schm, { foo: 'foo' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 'foo' }, schm)).resolves.toMatchSnapshot()
   })
 
   it('throws if value is not an array', () => {
@@ -273,7 +273,7 @@ describe('enum', () => {
         enum: 'foo',
       },
     })
-    expect(() => validate(schm, { foo: 'foo' })).toThrow()
+    expect(() => validate({ foo: 'foo' }, schm)).toThrow()
   })
 })
 
@@ -285,7 +285,7 @@ describe('max', () => {
         max: 1,
       },
     })
-    await expect(validate(schm, { foo: 2 })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 2 }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -295,7 +295,7 @@ describe('max', () => {
         max: [1, 'foo'],
       },
     })
-    await expect(validate(schm, { foo: 2 })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 2 }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -305,7 +305,7 @@ describe('max', () => {
         max: 1,
       },
     })
-    await expect(validate(schm, { foo: 1 })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 1 }, schm)).resolves.toMatchSnapshot()
   })
 })
 
@@ -317,7 +317,7 @@ describe('min', () => {
         min: 2,
       },
     })
-    await expect(validate(schm, { foo: 1 })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 1 }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -327,7 +327,7 @@ describe('min', () => {
         min: [2, 'foo'],
       },
     })
-    await expect(validate(schm, { foo: 1 })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: 1 }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -337,7 +337,7 @@ describe('min', () => {
         min: 2,
       },
     })
-    await expect(validate(schm, { foo: 2 })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: 2 }, schm)).resolves.toMatchSnapshot()
   })
 })
 
@@ -349,7 +349,7 @@ describe('maxlength', () => {
         maxlength: 1,
       },
     })
-    await expect(validate(schm, { foo: '12' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: '12' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -359,7 +359,7 @@ describe('maxlength', () => {
         maxlength: [1, 'foo'],
       },
     })
-    await expect(validate(schm, { foo: '12' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: '12' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -369,7 +369,7 @@ describe('maxlength', () => {
         maxlength: 1,
       },
     })
-    await expect(validate(schm, { foo: '1' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: '1' }, schm)).resolves.toMatchSnapshot()
   })
 })
 
@@ -381,7 +381,7 @@ describe('minlength', () => {
         minlength: 2,
       },
     })
-    await expect(validate(schm, { foo: '1' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: '1' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('fails with value and message array', async () => {
@@ -391,7 +391,7 @@ describe('minlength', () => {
         minlength: [2, 'foo'],
       },
     })
-    await expect(validate(schm, { foo: '1' })).rejects.toMatchSnapshot()
+    await expect(validate({ foo: '1' }, schm)).rejects.toMatchSnapshot()
   })
 
   it('passes', async () => {
@@ -401,7 +401,7 @@ describe('minlength', () => {
         minlength: 2,
       },
     })
-    await expect(validate(schm, { foo: '12' })).resolves.toMatchSnapshot()
+    await expect(validate({ foo: '12' }, schm)).resolves.toMatchSnapshot()
   })
 })
 
@@ -416,5 +416,5 @@ test('validator must be a function', () => {
       bar: true,
     },
   }))
-  expect(() => validate(schm, {})).toThrow()
+  expect(() => validate({}, schm)).toThrow()
 })


### PR DESCRIPTION
Now it's `validate(values, schema)` and `parse(values, schema)` instead of `parse(schema, values)`