### PR TITLE
[koa] cannot handle async middleware after body and query middleware.…

### DIFF
--- a/packages/schm-koa/src/index.js
+++ b/packages/schm-koa/src/index.js
@@ -36,7 +36,7 @@ export const query = (params: Object) => async (
   const values = qs.parse(convertEmptyToTrue(ctx.query));
   try {
     ctx.state.query = await querySchema.validate(values);
-    next();
+    await next();
   } catch (e) {
     ctx.state.schmError = true;
     throw e;
@@ -66,7 +66,7 @@ export const body = (params: Object) => async (ctx: Object, next: Function) => {
   const bodySchema = schema(params);
   try {
     ctx.state.body = await bodySchema.validate(ctx.request.body);
-    next();
+    await next();
   } catch (e) {
     ctx.state.schmError = true;
     throw e;

--- a/packages/schm-koa/test/index.test.js
+++ b/packages/schm-koa/test/index.test.js
@@ -12,6 +12,15 @@ const createApp = middleware => {
   app.use(bodyParser());
   app.use(errorHandler());
   app.use(middleware);
+  app.use(async (ctx, next) => {
+    async function sign() {
+      return new Promise((resolve) => {
+        setTimeout(resolve, 500, "random");
+      })
+    }
+    await sign();
+    next();
+  });
   app.use(ctx => {
     ctx.body = ctx.state;
   });


### PR DESCRIPTION
… I simply replaced "next()" by "await next()" in both query and body middleware functions.
I also added an async middleware as a test case to show where it fails.