### PR TITLE
Enabling translation for nested schemas

### DIFF
--- a/packages/schm-translate/test/index.test.js
+++ b/packages/schm-translate/test/index.test.js
@@ -26,3 +26,23 @@ test("parse without values", () => {
 
   expect(schm.parse()).toEqual({ name: undefined });
 });
+
+test("parse nested schemas", () => {
+  const schm = schema(
+    {
+      name: String
+    },
+    translate({
+      name: "foo.bar"
+    })
+  );
+
+  const nested = schema({
+    dog: String,
+    owner: schm
+  });
+
+  expect(
+    nested.parse({ dog: "Fido", owner: { foo: { bar: "John" } } })
+  ).toEqual({ dog: "Fido", owner: { name: "John" } });
+});

--- a/packages/schm/src/mapValues.js
+++ b/packages/schm/src/mapValues.js
@@ -1,5 +1,5 @@
 // @flow
-import { toArray, isArray, isSchema } from "./utils";
+import { toArray, isArray } from "./utils";
 
 type TransformValueFunction = (
   value: any,
@@ -36,12 +36,6 @@ const mapValues: MapValuesFunction = (
         transformValueFn(val, opt, paramName, [paramPath, i].join("."))
       );
       return mergeParam(finalValue);
-    }
-
-    if (isSchema(options.type)) {
-      return mergeParam(
-        mapValues(value, options.type.params, transformValueFn, [paramPath])
-      );
     }
 
     return mergeParam(transformValueFn(value, options, paramName, paramPath));


### PR DESCRIPTION
When using translation for nested schemas, the package ignores the new parse function for deep level schemas. This pull request fixes the issue assuring that deeper level schemas are correctly "translated".